### PR TITLE
日本語Windows環境でインストール時にUnicodeDecodeErrorが発生するのを修正

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class Tox(Command):
         errno = subprocess.call('tox')
         raise SystemExit(errno)
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 with open('VERSION') as version_file:


### PR DESCRIPTION
日本語が含まれるREADME.rstを読み込もうとしているため、日本語Windows環境ではインストール時にUnicodeDecodeErrorが発生し、インストールに失敗していました。
読み込み時の文字コードを明示的に指定することで、エラーが出ないように修正しました。